### PR TITLE
New gravity demands again

### DIFF
--- a/src/RSABuilder.py
+++ b/src/RSABuilder.py
@@ -556,10 +556,10 @@ if __name__ == "__main__":
     demands = demand_ordering.demand_order_sizes(demands)
     print(demands)
 
-    p = AllRightBuilder(G, demands, 1, slots=320).limited().path_type(AllRightBuilder.PathType.SHORTEST).dynamic_vars().construct()
+    p = AllRightBuilder(G, demands, 1, slots=320).limited().path_type(AllRightBuilder.PathType.SHORTEST).one_path().construct()
     print(p.get_build_time())
     print(p.solved())
-    p.draw(100)
+    p.draw(100, controllable=False)
 
     exit()
 

--- a/src/RSABuilder.py
+++ b/src/RSABuilder.py
@@ -64,7 +64,8 @@ class AllRightBuilder:
         self.__number_of_slots = slots
         self.__channel_data = None
         
-        self.__modulation = { 0: 3, 250: 4}
+        #self.__modulation = { 0: 3, 250: 4}
+        self.__modulation = {0:1}
         
         self.__onepath = False
 
@@ -545,17 +546,20 @@ class AllRightBuilder:
                 time.sleep(fps)  
             else:
                 input("Proceed?")
-            
+    
 if __name__ == "__main__":
     G = topology.get_nx_graph("topologies/japanese_topologies/dt.gml")
     #G = topology.get_nx_graph("topologies/topzoo/Ai3.gml")
-    demands = topology.get_demands_size_x(G, 15 ,seed=10,size=2)
+    #demands = topology.get_demands_size_x(G, 15 ,seed=10,size=1)
+    #demands = topology.get_gravity_demands2_nodes_have_constant_size(G, 15)
+    demands = topology.get_gravity_demands_v3(G, 10)
     demands = demand_ordering.demand_order_sizes(demands)
     print(demands)
-    p = AllRightBuilder(G, demands, 1, slots=320).modulation({0:1}).limited().path_type(AllRightBuilder.PathType.DISJOINT).one_path().construct()
+
+    p = AllRightBuilder(G, demands, 1, slots=320).limited().path_type(AllRightBuilder.PathType.SHORTEST).dynamic_vars().construct()
     print(p.get_build_time())
     print(p.solved())
-    p.draw(10)
+    p.draw(100)
 
     exit()
 

--- a/src/niceBDDBlocks.py
+++ b/src/niceBDDBlocks.py
@@ -761,7 +761,8 @@ class DynamicVarsNoClashBlock():
                                 if len(channel2) != modulation(base.paths[path2]) * base.demand_vars[d2].size:
                                     continue
                                 
-                                if (base.get_index(channel1, ET.CHANNEL), base.get_index(channel2, ET.CHANNEL)) in base.overlapping_channels:
+                                if (channel1[0] >= channel2[0] and channel1[0] <= channel2[-1]) \
+                                or (channel2[0] >= channel1[0] and channel2[0] <= channel1[-1]):
                                     big_overlap_expr &= (~(base.encode(ET.PATH, ip, d1) & base.encode(ET.PATH, jp, d2)) | ~(base.encode(ET.CHANNEL, ic, d1) & base.encode(ET.CHANNEL, jc, d2)))
                 
                 self.expr &= big_overlap_expr

--- a/src/rsa/rsa_draw.py
+++ b/src/rsa/rsa_draw.py
@@ -83,10 +83,8 @@ def draw_assignment_path_vars(assignment: dict[str, bool], base, paths: list[lis
                 return True
             
         return False
-        
+
     network = nx.create_empty_copy(topology)
-    colors = {str(k):0 for k in base.demand_vars.keys()}
-    
     demand_to_chosen_channel = {str(k):0 for k in base.demand_vars.keys()}
 
     for k, v in assignment.items():
@@ -127,16 +125,16 @@ def draw_assignment_path_vars(assignment: dict[str, bool], base, paths: list[lis
             path_index = base.d_to_paths[demand_id][path_index]
         
         path = paths[path_index]
-        channel_index = demand_to_chosen_channel[str(demand_id)]
 
         for source, target, number in path:
+            channel_index = demand_to_chosen_channel[str(demand_id)]
             channel = unique_channels[channel_index]
             
             if isinstance(base, DynamicVarsBDD):
-                print(channel_index)
-                print(len(base.demand_to_channels[demand_id]))
                 channel = base.demand_to_channels[demand_id][channel_index]
-                channel_index = base.get_index(channel, ET.CHANNEL)
+                # we found the local channel the index corresponds to and now we set it back to the global index
+                # s.t. the rest of the code does not need to take dynamic vars into account
+                channel_index = base.get_index(channel, ET.CHANNEL)                
 
             if not overlaps(channel_index, slots_used_on_edges[(source, target, number)], base):
                 network.add_edge(source, target, label=f"[{channel[0]},{channel[-1]}]", color=color_short_hands[int(demand_id)])
@@ -145,7 +143,6 @@ def draw_assignment_path_vars(assignment: dict[str, bool], base, paths: list[lis
                 print("Error found")
             
             slots_used_on_edges[(source, target, number)].append(channel_index)
-            #network.add_edge(source, target, label=f"[{channel[0]},{channel[-1]}]", color=color_short_hands[int(demand_id)])
         
     edge_colors = nx.get_edge_attributes(network,'color').values()
     

--- a/src/topology.py
+++ b/src/topology.py
@@ -343,10 +343,7 @@ def get_overlapping_channels(demand_channels: dict[int, list[list[int]]]):
                 unique_channels.append(channel)
    
     overlapping_channels = []
-    # for i in range(unique_channels):
-    #     for j in range(unique_channels):
-    #         if unique_channels[i][0] > 
-    
+
     # Precompute sets and their lengths
     unique_sets = [set(channel) for channel in unique_channels]
     set_lengths = [len(channel_set) for channel_set in unique_sets]

--- a/src/topology.py
+++ b/src/topology.py
@@ -362,7 +362,7 @@ def get_overlapping_channels(demand_channels: dict[int, list[list[int]]]):
 
             if combined_set_length < length_i + length_j:
                 overlapping_channels.append((i, j))
-                #overlapping_channels.append((j,i))
+                overlapping_channels.append((j,i))
 
     return overlapping_channels, unique_channels
 

--- a/src/topology.py
+++ b/src/topology.py
@@ -114,6 +114,53 @@ def get_demands_size_x(graph: nx.MultiDiGraph, amount: int, seed=10, offset = 0,
     return ds
 
 
+def get_gravity_demands_v3(graph: nx.MultiDiGraph, amount: int, seed=10, offset=0, highestuniformthing=7, max_uniform=30, multiplier=5):
+    def get_s_and_t_based_on_size(node_to_size, connected):
+        total = sum(node_to_size.values())
+        
+        # Note that nodes are shuffled before call, so node 16 can have lower probability than node 0. 
+        nodes = list(node_to_size.keys())
+        probability_distribution = [round(size/total, 2) for size in node_to_size.values()]
+
+        while True:
+            # Pick k random elements from population list based on the given weights (equal prob if none given)
+            source_and_target = random.choices(population=nodes, weights=probability_distribution, k=2)
+            source_node = source_and_target[0]
+            target_node = source_and_target[1]
+            
+            if source_node != target_node and target_node in connected[source_node]:
+                return source_node, target_node
+                
+    random.seed(seed)
+    
+    connected = {s: [n for n in list(nx.single_source_shortest_path(graph,s).keys()) if n != s] for s in graph.nodes()}
+    connected = {s: v for s,v in connected.items() if len(v) > 0}
+    demands = {}
+    
+    node_to_size = {}
+    increment = (highestuniformthing) / len(graph.nodes)
+    value = 1
+    nodes = []
+
+    for n in graph.nodes(): 
+        nodes.append(n)
+
+    random.shuffle(nodes)
+
+    # Dont know if we want to assign sizes to cities in a different way
+    for n in nodes: 
+        node_to_size[n] = value
+        value += increment
+    
+    bound = math.floor(max_uniform / multiplier)
+    
+    for _ in range(amount): 
+        s,t = get_s_and_t_based_on_size(node_to_size, connected)
+        demand_size = random.choice([(i+1)*multiplier for i in range(0, bound)])
+        demands[len(demands)+offset] = Demand(s, t, demand_size)
+
+    return demands
+    
 
 class ReducedDemands:
     def __init__(self, demands, reduction_factor, unique_channels, wasted_frequencies, percentage_size_increase, fewer_channels):
@@ -289,14 +336,17 @@ def get_channels(demands, number_of_slots, limit=False, cliques=[], clique_limit
 
 def get_overlapping_channels(demand_channels: dict[int, list[list[int]]]):
     unique_channels = []
-    print(demand_channels)
+
     for channels in demand_channels.values():
         for channel in channels:
             if channel not in unique_channels:
                 unique_channels.append(channel)
    
     overlapping_channels = []
- 
+    # for i in range(unique_channels):
+    #     for j in range(unique_channels):
+    #         if unique_channels[i][0] > 
+    
     # Precompute sets and their lengths
     unique_sets = [set(channel) for channel in unique_channels]
     set_lengths = [len(channel_set) for channel_set in unique_sets]
@@ -312,6 +362,7 @@ def get_overlapping_channels(demand_channels: dict[int, list[list[int]]]):
 
             if combined_set_length < length_i + length_j:
                 overlapping_channels.append((i, j))
+                #overlapping_channels.append((j,i))
 
     return overlapping_channels, unique_channels
 


### PR DESCRIPTION
1. Tilføjede nye gravity demands som vi snakkede med Jiri om. Source og target vælges ud fra en sandsynlighed tildelt hver by (størrelse / sum af alle størrelser). 

2. Fiksede en "fejl" i chatGPTs overlapping channels. Den lavede ikke symmetriske channel par, fx var (2,1) i listen, men ej (1,2), og dette er ikke kompatibelt med vores d1 <= d2 if statement i full no clash. Så nu tilføjer vi både (i,j) og (j,i) i stedet for kun (i,j). 

3. Har tilføjet error detection til draw via af noget vi tidligere havde lavet. Så den skulle gerne printe fejl samt markere edges med overlapping channels nu. 

Misc. 
Har sat modulation default til {0:1}, da det lød til vi alligevel vil ignorere den for nu. Og fiksede en meget langsom linje i dynamic vars NoClash block.